### PR TITLE
SSCLI Removes `.html` from the sitemap

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Generate sitemap
         run: |
           cd book
-          npx sscli --base https://rust-cli-recommendations.sunshowers.io
+          npx sscli --no-clean --base https://rust-cli-recommendations.sunshowers.io
       - name: Deploy
         uses: JamesIves/github-pages-deploy-action@releases/v4
         with:


### PR DESCRIPTION
The links work without `.html` but this means that Google has 2 links for the same content without a canonical link https://developers.google.com/search/docs/crawling-indexing/consolidate-duplicate-urls 